### PR TITLE
Configuration: Put parameters in quotes as it is deprecated without

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is useful when you want to transform domain/business exception from your co
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/RiperFr/ExceptionTransformerBundle/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/RiperFr/ExceptionTransformerBundle/?branch=master)
 ![License CC-BY-4](https://img.shields.io/badge/licence-CC--BY--4.0-blue.svg)
 ![php version](https://img.shields.io/badge/php->=5.3.5,%205.4,%205.5,%205.6,%207-blue.svg)
-![symfony version](https://img.shields.io/badge/symfony-2.6,%202.7,%202.8,%203-blue.svg)
+![symfony version](https://img.shields.io/badge/symfony-2.6,%202.7,%202.8,%203.*-blue.svg)
 
 
 [![SensioLabsInsight](https://insight.sensiolabs.com/projects/f72a264e-1e57-4973-b953-8fe3465792e9/big.png)](https://insight.sensiolabs.com/projects/f72a264e-1e57-4973-b953-8fe3465792e9)

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -7,9 +7,9 @@ services:
     #The name of the service is referenced in the code. Caution if changed
     riper.exception_transformer.transformers.http_exception_transformer:
         class: Riper\Bundle\ExceptionTransformerBundle\ExceptionTransformer\HttpExceptionTransformer
-        arguments : [ %riper_exception_mapping.shortcuts% ]
+        arguments : [ "%riper_exception_mapping.shortcuts%" ]
         calls :
-            - [ "addMap" , [ %riper_exception_mapping.exception_map% ] ]
+            - [ "addMap" , [ "%riper_exception_mapping.exception_map%" ] ]
         tags:
             - { name: riper.exception.transformer, namespace_scope: "" }
 
@@ -22,6 +22,6 @@ services:
 
 #    riper.error_handler.exception_to_http_exception_listener:
 #            class: Riper\Bundle\ErrorRendererBundle\Listener\ExceptionToHttpExceptionListener
-#            arguments : [ %riper_exception_mapping% ]
+#            arguments : [ "%riper_exception_mapping%" ]
 #            tags:
 #                - { name : kernel.event_subscriber }


### PR DESCRIPTION
In order to avoid miss interpretation in yaml, Symfony deprecated the
usage of parameters (`%something%`) without quotes.